### PR TITLE
클라이언트 컴포넌트로 일부 변경 (list pages with filter)

### DIFF
--- a/src/app/_deprecated/select.tsx
+++ b/src/app/_deprecated/select.tsx
@@ -1,6 +1,5 @@
-"use client";
 import clsx from "clsx";
-import { useRouter } from "next/navigation";
+import Link from "next/link";
 
 export interface SelectItemType<T> {
   label: string;
@@ -10,20 +9,18 @@ export interface SelectItemType<T> {
 interface Props<T> {
   baseUrl: string;
   name: string;
-  selected: string;
   items: SelectItemType<T>[];
+  selectedItem: string;
   sticky?: boolean;
 }
 
 export default function Select<T>({
   baseUrl,
   name,
-  selected,
   items,
+  selectedItem,
   sticky = false,
 }: Props<T>) {
-  const router = useRouter();
-  console.log(items, selected);
   return (
     <ul
       className={clsx(
@@ -32,18 +29,18 @@ export default function Select<T>({
       )}
     >
       {items.map(({ label, value }: SelectItemType<T>) => (
-        <button
+        <Link
           key={`${value}`}
+          href={`${baseUrl}?${name}=${value}`}
           className={clsx(
             "rounded-full px-4 py-2 text-bd2 cursor-pointer whitespace-nowrap",
-            selected === value
+            selectedItem === value
               ? "bg-accent-purple text-black"
               : "text-white bg-shadow-800"
           )}
-          onClick={() => router.replace(`${baseUrl}?${name}=${value}`)}
         >
           {label}
-        </button>
+        </Link>
       ))}
     </ul>
   );

--- a/src/app/card/benefit/page.tsx
+++ b/src/app/card/benefit/page.tsx
@@ -1,10 +1,18 @@
-import Select, { SelectItemType } from "@/app/(_components)/select";
+"use client";
+import { SelectItemType } from "@/app/_deprecated/select";
 import { PATH } from "@/lib/_shared/paths";
 import BestCard from "./(components)/best-card";
 import OtherBenefit from "./(components)/other-benefit";
-import { notFound } from "next/navigation";
+import { notFound, useSearchParams } from "next/navigation";
+import SelectClient from "@/app/(_components)/select";
+import { Benefit, BenefitType } from "@/types/card";
+import { isBenefitType } from "@/utils/typeCheck";
 
-const categories: SelectItemType<BenefitValueType>[] = [
+const categories: SelectItemType<BenefitType>[] = [
+  {
+    label: "전체",
+    value: "all",
+  },
   {
     label: "교통",
     value: "traffic",
@@ -35,41 +43,19 @@ const categories: SelectItemType<BenefitValueType>[] = [
   },
 ];
 
-const BENEFIT_CATEGORY: BenefitValueType[] = [
-  "traffic",
-  "communication",
-  "abroad",
-  "oiling",
-  "mart",
-  "shopping",
-  "cafe",
-];
+export default function CardBenefitPage() {
+  const searchParams = useSearchParams();
+  const category = searchParams.get("category") ?? "all";
 
-export type BenefitValueType =
-  | "traffic"
-  | "communication"
-  | "abroad"
-  | "oiling"
-  | "mart"
-  | "shopping"
-  | "cafe";
-
-interface Props {
-  searchParams: Promise<{ category: string }>;
-}
-
-export default async function CardBenefitPage({ searchParams }: Props) {
-  const { category } = await searchParams;
-  if (category && !BENEFIT_CATEGORY.includes(category as BenefitValueType))
-    throw notFound();
+  if (!isBenefitType(category)) return notFound();
 
   return (
     <div className="flex flex-col gap-5">
-      <Select
+      <SelectClient
         baseUrl={PATH.CARD_BENEFIT}
         name="category"
+        selected={category}
         items={categories}
-        selectedItem={category ?? "traffic"}
       />
       <BestCard />
       <OtherBenefit />

--- a/src/app/forest/store/page.tsx
+++ b/src/app/forest/store/page.tsx
@@ -1,10 +1,11 @@
 "use client";
 import Image from "next/image";
-import Select from "@/app/(_components)/select";
 import { PATH } from "@/lib/_shared/paths";
 import StoreItemCard from "../(components)/store-item-card";
 import { useModal } from "@/lib/_hooks/useModal";
-import { useSearchParams } from "next/navigation";
+import { notFound, useSearchParams } from "next/navigation";
+import Select from "@/app/(_components)/select";
+import { isItemCategoryType } from "@/utils/typeCheck";
 
 const categories = [
   { label: "전체", value: "all" },
@@ -25,12 +26,11 @@ const storeItems = [
   imgUrl: `/temp/forest/ground-item${idx + 1}.png`,
 }));
 
-interface Props {
-  searchParams: { category: string };
-}
 export default function Page() {
   const searchParams = useSearchParams();
-  const category = searchParams.get("category");
+  const category = searchParams.get("category") ?? "all";
+
+  if (!isItemCategoryType(category)) return notFound();
 
   // TODO: user's coin, store data fetching api
   const userCoins = 1618;
@@ -45,8 +45,8 @@ export default function Page() {
       <Select
         baseUrl={PATH.FOREST_STORE}
         name="category"
+        selected={category}
         items={categories}
-        selectedItem={category ?? "all"}
       />
       <div className="w-full gap-2 flex justify-end">
         <Image

--- a/src/app/funding/list/page.tsx
+++ b/src/app/funding/list/page.tsx
@@ -1,13 +1,11 @@
-import Select, { SelectItemType } from "@/app/(_components)/select";
+"use client";
 import { PATH } from "@/lib/_shared/paths";
-import { SearchParams } from "@/types/utils";
-import { FundingCategoryType } from "@/types/fundings";
 import { youth } from "../(_dummy)/list-data";
 import FundingList from "../(components)/funding-list";
-
-interface Props {
-  searchParams: SearchParams;
-}
+import Select, { SelectItemType } from "@/app/(_components)/select";
+import { notFound, useSearchParams } from "next/navigation";
+import { FundingCategory, FundingCategoryType } from "@/types/fundings";
+import { isFundingCategoryType } from "@/utils/typeCheck";
 
 const categories: SelectItemType<FundingCategoryType>[] = [
   { label: "전체", value: "all" },
@@ -15,16 +13,20 @@ const categories: SelectItemType<FundingCategoryType>[] = [
   { label: "동물", value: "animal" },
   { label: "아동・청소년", value: "youth" },
 ];
-export default async function FundRaisingsListPage({ searchParams }: Props) {
-  const { category } = await searchParams;
+export default function FundRaisingsListPage() {
+  const searchParams = useSearchParams();
+  const category = searchParams.get("category") ?? "all";
+
+  if (!isFundingCategoryType(category)) return notFound();
+
   // TODO: data fetching by category
   return (
     <>
       <Select
         baseUrl={PATH.FUNDING_LIST}
         name="category"
+        selected={category as string}
         items={categories}
-        selectedItem={(category as string) ?? "all"}
         sticky
       />
       <FundingList category={category as string} listData={youth} />

--- a/src/app/payments/(components)/payments-list.tsx
+++ b/src/app/payments/(components)/payments-list.tsx
@@ -2,9 +2,9 @@
 import clsx from "clsx";
 import { useEffect, useState } from "react";
 import PaymentsItem from "./payments-item";
-import Select, { SelectItemType } from "@/app/(_components)/select";
+import Select, { SelectItemType } from "@/app/_deprecated/select";
 import { PATH } from "@/lib/_shared/paths";
-import { CategoryValueType } from "../page";
+import { PaymentCategoryType } from "@/types/pay";
 
 export interface PaymentsType {
   orderName: string;
@@ -49,14 +49,15 @@ const payments: PaymentsType[] = [
 ];
 
 export default function PaymentsList() {
-  const [selectedItem, setSelectedItem] = useState<CategoryValueType>("all");
+  const [selectedItem, setSelectedItem] = useState<PaymentCategoryType>("all");
   const [orderBy, setOrderBy] = useState<OrderByType>("recent");
 
   const isAll = selectedItem === "all";
 
   // TODO: data fetching (SWR)
 
-  const onClickCategory = (value: CategoryValueType) => setSelectedItem(value);
+  const onClickCategory = (value: PaymentCategoryType) =>
+    setSelectedItem(value);
   const onClickOrderBy = (value: OrderByType) => setOrderBy(value);
 
   useEffect(() => {

--- a/src/app/payments/page.tsx
+++ b/src/app/payments/page.tsx
@@ -3,7 +3,7 @@ import { PATH } from "@/lib/_shared/paths";
 import PaymentsList from "./(components)/payments-list";
 import clsx from "clsx";
 import { notFound, useRouter, useSearchParams } from "next/navigation";
-import { PaymentCategory, PaymentCategoryType } from "@/types/pay";
+import { PaymentCategoryType, PaymentSorting } from "@/types/pay";
 import Select, { SelectItemType } from "../(_components)/select";
 import { isPaymentCategoryType, isPaymentSortingType } from "@/utils/typeCheck";
 
@@ -36,7 +36,7 @@ export default function PaymentsPage() {
         <button
           onClick={() =>
             router.replace(
-              `${PATH.PAYMENTS}?category=${category}&sorting=${PaymentCategory[0]}`
+              `${PATH.PAYMENTS}?category=${category}&sorting=${PaymentSorting[0]}`
             )
           }
           className={clsx(sorting !== "latest" && "opacity-80")}
@@ -49,7 +49,7 @@ export default function PaymentsPage() {
             <button
               onClick={() =>
                 router.replace(
-                  `${PATH.PAYMENTS}?category=${category}&sorting=${PaymentCategory[1]}`
+                  `${PATH.PAYMENTS}?category=${category}&sorting=${PaymentSorting[1]}`
                 )
               }
               className={clsx(sorting !== "desc" && "opacity-70")}

--- a/src/app/payments/page.tsx
+++ b/src/app/payments/page.tsx
@@ -1,57 +1,61 @@
-import Select, { SelectItemType } from "@/app/(_components)/select";
+"use client";
 import { PATH } from "@/lib/_shared/paths";
 import PaymentsList from "./(components)/payments-list";
 import clsx from "clsx";
-import Link from "next/link";
-import { notFound, redirect } from "next/navigation";
+import { notFound, useRouter, useSearchParams } from "next/navigation";
+import { PaymentCategory, PaymentCategoryType } from "@/types/pay";
+import Select, { SelectItemType } from "../(_components)/select";
+import { isPaymentCategoryType, isPaymentSortingType } from "@/utils/typeCheck";
 
-export type CategoryValueType = "all" | "pay" | "add";
-
-type Props = {
-  searchParams: { [key: string]: string | undefined };
-};
-
-const categories: SelectItemType<CategoryValueType>[] = [
+const categories: SelectItemType<PaymentCategoryType>[] = [
   { label: "전체", value: "all" },
   { label: "결제", value: "pay" },
   { label: "충전", value: "add" },
 ];
 
-const types = ["all", "pay", "add"];
-const sortingOptions = ["recent", "desc"];
+export default function PaymentsPage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const category = searchParams.get("category") ?? "all";
+  const sorting = searchParams.get("sorting") ?? "latest";
 
-export default async function PaymentsPage({ searchParams }: Props) {
-  const { type, sort } = await searchParams;
+  if (!isPaymentCategoryType(category)) return notFound();
+  if (!isPaymentSortingType(sorting)) return notFound();
 
-  const isAll = type === "all";
-
-  if (type && !types.includes(type)) redirect(notFound());
-  if (sort && !sortingOptions.includes(sort)) redirect(notFound());
+  const isAll = category === "all";
 
   return (
     <>
       <Select
         baseUrl={PATH.PAYMENTS}
-        name="type"
+        name="category"
+        selected={category}
         items={categories}
-        selectedItem={type ?? "all"}
       />
       <div className="py-3 border-y border-white justify-end gap-2 flex divide-white select-none text-bd3 font-bold ">
-        <Link
-          href={`${PATH.PAYMENTS}?type=${type ?? "all"}&sort=recent`}
-          className={clsx(sort && sort !== "recent" && "opacity-80")}
+        <button
+          onClick={() =>
+            router.replace(
+              `${PATH.PAYMENTS}?category=${category}&sorting=${PaymentCategory[0]}`
+            )
+          }
+          className={clsx(sorting !== "latest" && "opacity-80")}
         >
           최신순
-        </Link>
+        </button>
         {!isAll && (
           <>
             <span>|</span>
-            <Link
-              href={`${PATH.PAYMENTS}?type=${type ?? "all"}&sort=desc`}
-              className={clsx(sort !== "desc" && "opacity-70")}
+            <button
+              onClick={() =>
+                router.replace(
+                  `${PATH.PAYMENTS}?category=${category}&sorting=${PaymentCategory[1]}`
+                )
+              }
+              className={clsx(sorting !== "desc" && "opacity-70")}
             >
               고액순
-            </Link>
+            </button>
           </>
         )}
       </div>

--- a/src/types/card.ts
+++ b/src/types/card.ts
@@ -1,0 +1,12 @@
+export const Benefit = [
+  "all",
+  "traffic",
+  "communication",
+  "abroad",
+  "oiling",
+  "mart",
+  "shopping",
+  "cafe",
+] as const;
+
+export type BenefitType = (typeof Benefit)[number];

--- a/src/types/forest.ts
+++ b/src/types/forest.ts
@@ -1,0 +1,3 @@
+export const ItemCategory = ["all", "sky", "ground"];
+
+export type ItemCategoryType = (typeof ItemCategory)[number];

--- a/src/types/fundings.ts
+++ b/src/types/fundings.ts
@@ -1,1 +1,8 @@
-export type FundingCategoryType = "all" | "environment" | "animal" | "youth";
+export const FundingCategory = [
+  "all",
+  "environment",
+  "animal",
+  "youth",
+] as const;
+
+export type FundingCategoryType = (typeof FundingCategory)[number];

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,0 @@
-import * as utils from "./utils";
-
-export { utils };

--- a/src/types/pay.ts
+++ b/src/types/pay.ts
@@ -1,0 +1,5 @@
+export const PaymentCategory = ["all", "pay", "add"] as const;
+export const PaymentSorting = ["latest", "desc"] as const;
+
+export type PaymentCategoryType = (typeof PaymentCategory)[number];
+export type PaymentSortingType = (typeof PaymentSorting)[number];

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -1,3 +1,0 @@
-export type SearchParams = Promise<{
-  [key: string]: string | string[] | undefined;
-}>;

--- a/src/utils/typeCheck.ts
+++ b/src/utils/typeCheck.ts
@@ -1,0 +1,27 @@
+import { BenefitType, Benefit } from "@/types/card";
+import { ItemCategory, ItemCategoryType } from "@/types/forest";
+import { FundingCategoryType, FundingCategory } from "@/types/fundings";
+import {
+  PaymentCategoryType,
+  PaymentCategory,
+  PaymentSortingType,
+  PaymentSorting,
+} from "@/types/pay";
+
+/** Payments */
+export const isPaymentCategoryType = (x: any): x is PaymentCategoryType =>
+  PaymentCategory.includes(x);
+
+export const isPaymentSortingType = (x: any): x is PaymentSortingType =>
+  PaymentSorting.includes(x);
+
+/** Benefit */
+export const isBenefitType = (x: any): x is BenefitType => Benefit.includes(x);
+
+/** Funding */
+export const isFundingCategoryType = (x: any): x is FundingCategoryType =>
+  FundingCategory.includes(x);
+
+/** Forest */
+export const isItemCategoryType = (x: any): x is ItemCategoryType =>
+  ItemCategory.includes(x);


### PR DESCRIPTION
## 작업내용

### `typeCheck` 유틸 함수 구현
사용자 정의 타입을 검사하기 위한 함수들을 모아 관리합니다
```js
// utils/typeCheck.ts
...
/** Payments */
export const isPaymentCategoryType = (x: any): x is PaymentCategoryType => PaymentCategory.includes(x);
```


### `Select`를 포함한 리스트 페이지를 클라이언트 컴포넌트로 변경
클라이언트에서 필터의 상태를 관리하여 라우팅 히스토리에 쌓이는 것을 방지합니다
기존) [교통]-> [통신] -> 뒤로가기 클릭시 [교통]탭으로 이동
변경) [교통]-> [통신] -> 뒤로가기 클릭시 홈화면으로 이동

[기존]

https://github.com/user-attachments/assets/aa851193-810b-4b16-b87c-70fc91b9bcf4 

[변경]

https://github.com/user-attachments/assets/67f321ed-9132-4a30-bdb0-e142542839ba

